### PR TITLE
修复 CI 大小写崩溃：data/system/Status.tjs 全引用统一大写 S

### DIFF
--- a/.github/workflows/release-data.yml
+++ b/.github/workflows/release-data.yml
@@ -89,7 +89,7 @@ jobs:
           set -euo pipefail
           python3 tools/inject_game_version.py \
             --tag "$RELEASE_TAG" \
-            --status data/system/status.tjs
+            --status data/system/Status.tjs
       - name: Generate and validate the content manifest
         shell: bash
         run: |

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -129,7 +129,7 @@ jobs:
           set -euo pipefail
           python3 tools/inject_game_version.py \
             --tag "$RELEASE_TAG" \
-            --status data/system/status.tjs
+            --status data/system/Status.tjs
 
       - name: Generate complete content manifest
         shell: bash

--- a/.github/workflows/release-windows-krkrz.yml
+++ b/.github/workflows/release-windows-krkrz.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           python tools/inject_game_version.py `
             --tag $env:RELEASE_TAG `
-            --status data/system/status.tjs
+            --status data/system/Status.tjs
           if ($LASTEXITCODE -ne 0) { throw 'Game version injection failed' }
 
       - name: Generate and validate the content manifest

--- a/tools/inject_game_version.py
+++ b/tools/inject_game_version.py
@@ -3,7 +3,7 @@
 
 The release tag is the single version source for every platform display
 version (Android/iOS/OHOS/macOS bundle versions and the in-game
-data/system/status.tjs GAME_VERSION alike). Extraction keeps the leading
+data/system/Status.tjs GAME_VERSION alike). Extraction keeps the leading
 numeric dotted sequence verbatim and drops everything after it:
 
     v1.0.0 -> 1.0.0      v1.0 -> 1.0      v1.01 -> 1.01
@@ -35,7 +35,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--tag", required=True,
                         help="Release tag, e.g. v1.0.0-ohos-x")
-    parser.add_argument("--status", default="data/system/status.tjs",
+    parser.add_argument("--status", default="data/system/Status.tjs",
                         help="status.tjs to rewrite in place")
     parser.add_argument("--dry-run", action="store_true",
                         help="Print the resolved version without writing")


### PR DESCRIPTION
git 索引与数据源分卷内的真实路径是 Status.tjs（大写 S）。三个
工作流的 GAME_VERSION 注入步骤与 inject_game_version.py 默认值 均写成小写 status.tjs：

- windows/macos runner 文件系统大小写不敏感，侥幸命中
- data 工作流的 ubuntu runner 大小写敏感，注入步骤直接 'No such file or directory'（android/ios/ohos 为 data-external 不注入，从未踩中）

统一改为 Status.tjs，并核对其余 data/ 文件引用无同类问题
（startup.tjs 索引即小写，一致）。