### PR TITLE
修复 Windows 发布缺子模块：checkout 补 submodules: recursive

### DIFF
--- a/.github/workflows/release-windows-krkrz.yml
+++ b/.github/workflows/release-windows-krkrz.yml
@@ -30,11 +30,12 @@ jobs:
     timeout-minutes: 90
 
     steps:
-      - name: Check out repository and LFS content
+      - name: Check out repository, submodules, and LFS content
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          # LFS content is restored further down from the Actions cache when
-          # possible; smudging here would always spend the LFS bandwidth.
+          submodules: recursive
+          # data/ pointer stubs are replaced further down by a full copy of
+          # the game data from the data source release; LFS is never pulled.
           lfs: false
 
       - name: Set up Python for the release manifest


### PR DESCRIPTION
release-windows-krkrz 是唯一没带 submodules 的发布工作流
（其余 5 个均有），actions/checkout 默认不检出子模块，导致 CI 上
external/ 为空，generate_notices 报 5 个 license 文件缺失、
THIRD-PARTY-NOTICES 生成失败。本机子模块已检出所以从未复现。

顺带把 checkout 步骤名与 lfs: false 注释更新为数据源 Release
拉取的现状。